### PR TITLE
make answer simpler

### DIFF
--- a/_build/directory/lang-spec/pointer/answer.txt
+++ b/_build/directory/lang-spec/pointer/answer.txt
@@ -9,6 +9,6 @@ func f() *S {
 }
 
 func main() {
-    p := *f()  //B
+    p := f()  //B
     print(p.m) //print "foo"
 }


### PR DESCRIPTION
we don't need to get the value of a pointer to print it.
and as we printing the value "m" inside the struct pointer.
so it's simpler to just not dereferencing it.